### PR TITLE
CMakeLists.txt: Make it build on Linux as well

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,8 +53,7 @@ if(WIN32)
         winmm
         gdi32
         ${MISC}
-        ${OPENGL_LIBRARIES}
-        glut
+        ${OPENGL_LIBRARIES}        
     )
 else()
     TARGET_LINK_LIBRARIES( ${PROJECT_NAME}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ cmake_minimum_required(VERSION 3.1)
 find_package(OpenGL REQUIRED)
 
 
-#-------------------------------------------------------------------------------
+#------------------------------------------------------------------------------
 # Build flags
 
 if(DEFINED CMAKE_COMPILER_IS_GNUCC)
@@ -13,17 +13,19 @@ if(DEFINED CMAKE_COMPILER_IS_GNUCC)
     SET( CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -std=c++0x" )
 endif()
 
-add_definitions( -DFREEGLUT_STATIC )
+if(DEFINED WIN32)
+    add_definitions( -DFREEGLUT_STATIC )
+endif()
 
-#-------------------------------------------------------------------------------
+#------------------------------------------------------------------------------
 # List of headers locations
 include_directories(
     ${CMAKE_CURRENT_SOURCE_DIR}
-    ${CMAKE_CURRENT_SOURCE_DIR}/src      
+    ${CMAKE_CURRENT_SOURCE_DIR}/src
     ${OPENGL_INCLUDE_DIR}
 )
 
-#-------------------------------------------------------------------------------
+#------------------------------------------------------------------------------
 # List of cpu sources
 file(GLOB_RECURSE host_sources ${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp)
 
@@ -33,25 +35,32 @@ file(GLOB_RECURSE headers
     ${CMAKE_CURRENT_SOURCE_DIR}/src/*.inl
 )
 
-#-------------------------------------------------------------------------------
+#------------------------------------------------------------------------------
 # The project build setup
 
 ADD_EXECUTABLE( ${PROJECT_NAME} ${host_sources} ${headers})
 
-#-------------------------------------------------------------------------------
+#------------------------------------------------------------------------------
 # Link application with opengl glu etc
 
 if(WIN32)
     if(MINGW)
         set(MISC -static-libgcc -static-libstdc++)
     endif()
-endif()
 
-TARGET_LINK_LIBRARIES( ${PROJECT_NAME}
-    freeglut_static
-    winmm  
-    gdi32      
-    ${MISC}    
-    ${OPENGL_LIBRARIES}    
-)
+    TARGET_LINK_LIBRARIES( ${PROJECT_NAME}
+        freeglut_static
+        winmm
+        gdi32
+        ${MISC}
+        ${OPENGL_LIBRARIES}
+        glut
+    )
+else()
+    TARGET_LINK_LIBRARIES( ${PROJECT_NAME}
+        ${MISC}
+        ${OPENGL_LIBRARIES}
+        glut
+    )
+endif()
 


### PR DESCRIPTION
Fix some whitespace errors and reduce comment lines to below 80 columns.

Include winmm, gdi32 and freeglut_static on WIN32
only. Use glut on linux instead.